### PR TITLE
Bump nodemon version, see dominictarr/event-stream#116

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cross-spawn": "^6.0.5",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "json-loader": "^0.5.7",
-    "nodemon": "^1.18.4",
+    "nodemon": "^1.18.7",
     "ramda": "^0.25.0",
     "source-map-support": "^0.5.9",
     "webpack": "^4.20.2",


### PR DESCRIPTION
**Reason:**
Earlier nodemon versions relies on flatmap-stream, which is a malicious package.  

> nodemon@1.18.6
> │   └─┬ pstree.remy@1.1.0
> │     └─┬ ps-tree@1.1.0
> │       └─┬ event-stream@3.3.6
> │         └── flatmap-stream@0.1.2